### PR TITLE
Fix service discovery endpoint resolution

### DIFF
--- a/mcp_client_web/McpSseClient.cs
+++ b/mcp_client_web/McpSseClient.cs
@@ -1,23 +1,57 @@
 using ModelContextProtocol.Client;
 
+using Microsoft.Extensions.ServiceDiscovery;
+using System.Linq;
+using System.Net;
 using Throw;
 
 namespace mcp_client_web;
 
-public class McpSseClient(HttpClient httpClient, ILogger<McpSseClient> logger)
+public class McpSseClient(HttpClient httpClient,
+                          ServiceEndpointResolver endpointResolver,
+                          ILogger<McpSseClient> logger)
 {
-	public async Task<IMcpClient> CreateAsync(CancellationToken cancellationToken = default)
-	{
-		httpClient.BaseAddress.ThrowIfNull();
-		logger.LogInformation("Creating MCP client with base address: {BaseAddress}", httpClient.BaseAddress);
-		return await McpClientFactory.CreateAsync(
-			clientTransport: new SseClientTransport(
-				new SseClientTransportOptions
-				{
-					Endpoint = new Uri("https://localhost:7040") // httpClient.BaseAddress
-				}
-			),
-			cancellationToken: cancellationToken
-		);
-	}
+        public async Task<IMcpClient> CreateAsync(CancellationToken cancellationToken = default)
+        {
+                httpClient.BaseAddress.ThrowIfNull();
+                logger.LogInformation("Creating MCP client with base address: {BaseAddress}", httpClient.BaseAddress);
+
+                var source = await endpointResolver.GetEndpointsAsync(httpClient.BaseAddress.ToString(), cancellationToken);
+                var endpoint = source.Endpoints
+                        .Select(e => ConvertToUri(e.EndPoint))
+                        .FirstOrDefault(uri => uri is not null) ?? httpClient.BaseAddress!;
+
+                return await McpClientFactory.CreateAsync(
+                        clientTransport: new SseClientTransport(
+                                new SseClientTransportOptions
+                                {
+                                        Endpoint = endpoint
+                                }
+                        ),
+                        cancellationToken: cancellationToken
+                );
+        }
+
+        private static Uri? ConvertToUri(EndPoint ep)
+        {
+                if (ep == null)
+                {
+                        return null;
+                }
+
+                var type = ep.GetType();
+                // Handle internal UriEndPoint via reflection
+                var uriProp = type.GetProperty("Uri");
+                if (uriProp?.GetValue(ep) is Uri uri)
+                {
+                        return uri;
+                }
+
+                return ep switch
+                {
+                        DnsEndPoint dns => new UriBuilder("https", dns.Host, dns.Port).Uri,
+                        IPEndPoint ip => new UriBuilder("https", ip.Address.ToString(), ip.Port).Uri,
+                        _ => null
+                };
+        }
 }


### PR DESCRIPTION
## Summary
- resolve SSE endpoint using `ServiceEndpointResolver`
- pick first resolved URI via reflection for internal `UriEndPoint`

## Testing
- `dotnet build mcp_client_web/mcp_client_web.csproj -c Debug`
- `dotnet run --project aspire_apphost/aspire_apphost.csproj` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6848838e717883248bc67f30c2406f06