### PR TITLE
Add expanded family data

### DIFF
--- a/family_webapi/people.json
+++ b/family_webapi/people.json
@@ -4,6 +4,7 @@
     "name": "William Carter",
     "gender": "male",
     "yearOfBirth": 1945,
+    "placeOfBirth": "Wellington, New Zealand",
     "parents": [],
     "spouses": [
       "p2"
@@ -18,6 +19,7 @@
     "name": "Margaret Carter",
     "gender": "female",
     "yearOfBirth": 1947,
+    "placeOfBirth": "Dublin, Ireland",
     "parents": [],
     "spouses": [
       "p1"
@@ -32,6 +34,7 @@
     "name": "Elizabeth Carter",
     "gender": "female",
     "yearOfBirth": 1970,
+    "placeOfBirth": "Seville, Spain",
     "parents": [
       "p1",
       "p2"
@@ -49,6 +52,7 @@
     "name": "James Carter",
     "gender": "male",
     "yearOfBirth": 1972,
+    "placeOfBirth": "Barcelona, Spain",
     "parents": [
       "p1",
       "p2"
@@ -62,9 +66,10 @@
   },
   {
     "id": "p5",
-    "name": "Linda Carter (n\u00E9e Evans)",
+    "name": "Linda Carter (n\u00e9e Evans)",
     "gender": "female",
     "yearOfBirth": 1973,
+    "placeOfBirth": "Cape Town, South Africa",
     "parents": [
       "p12",
       "p13"
@@ -81,6 +86,7 @@
     "name": "Michael Evans",
     "gender": "male",
     "yearOfBirth": 1975,
+    "placeOfBirth": "Johannesburg, South Africa",
     "parents": [
       "p12",
       "p13"
@@ -98,6 +104,7 @@
     "name": "David Smith",
     "gender": "male",
     "yearOfBirth": 1968,
+    "placeOfBirth": "Perth, Australia",
     "parents": [
       "p16",
       "p17"
@@ -112,9 +119,10 @@
   },
   {
     "id": "p8",
-    "name": "Susan Smith (n\u00E9e Brown)",
+    "name": "Susan Smith (n\u00e9e Brown)",
     "gender": "female",
     "yearOfBirth": 1976,
+    "placeOfBirth": "Auckland, New Zealand",
     "parents": [
       "p18",
       "p19"
@@ -132,6 +140,7 @@
     "name": "Emily Smith",
     "gender": "female",
     "yearOfBirth": 1995,
+    "placeOfBirth": "Reykjavik, Iceland",
     "parents": [
       "p3",
       "p7"
@@ -148,6 +157,7 @@
     "name": "Matthew Smith",
     "gender": "male",
     "yearOfBirth": 1998,
+    "placeOfBirth": "Akureyri, Iceland",
     "parents": [
       "p3",
       "p7"
@@ -164,6 +174,7 @@
     "name": "Sophie Carter",
     "gender": "female",
     "yearOfBirth": 2000,
+    "placeOfBirth": "Prague, Czech Republic",
     "parents": [
       "p4",
       "p5"
@@ -178,6 +189,7 @@
     "name": "Robert Evans",
     "gender": "male",
     "yearOfBirth": 1950,
+    "placeOfBirth": "Lisbon, Portugal",
     "parents": [],
     "spouses": [
       "p13"
@@ -192,6 +204,7 @@
     "name": "Patricia Evans",
     "gender": "female",
     "yearOfBirth": 1952,
+    "placeOfBirth": "Edinburgh, United Kingdom",
     "parents": [],
     "spouses": [
       "p12"
@@ -206,6 +219,7 @@
     "name": "Daniel Evans",
     "gender": "male",
     "yearOfBirth": 2002,
+    "placeOfBirth": "Lille, France",
     "parents": [
       "p6",
       "p8"
@@ -221,6 +235,7 @@
     "name": "Olivia Evans",
     "gender": "female",
     "yearOfBirth": 2005,
+    "placeOfBirth": "Nice, France",
     "parents": [
       "p6",
       "p8"
@@ -235,6 +250,7 @@
     "name": "George Smith",
     "gender": "male",
     "yearOfBirth": 1943,
+    "placeOfBirth": "Bilbao, Spain",
     "parents": [],
     "spouses": [
       "p17"
@@ -248,6 +264,7 @@
     "name": "Helen Smith",
     "gender": "female",
     "yearOfBirth": 1944,
+    "placeOfBirth": "Bologna, Italy",
     "parents": [],
     "spouses": [
       "p16"
@@ -261,6 +278,7 @@
     "name": "Thomas Brown",
     "gender": "male",
     "yearOfBirth": 1950,
+    "placeOfBirth": "Odessa, Ukraine",
     "parents": [],
     "spouses": [
       "p19"
@@ -274,6 +292,7 @@
     "name": "Barbara Brown",
     "gender": "female",
     "yearOfBirth": 1951,
+    "placeOfBirth": "Brno, Czech Republic",
     "parents": [],
     "spouses": [
       "p18"
@@ -287,6 +306,7 @@
     "name": "Lucas Carter",
     "gender": "male",
     "yearOfBirth": 2024,
+    "placeOfBirth": "Ghent, Belgium",
     "parents": [
       "p9"
     ],
@@ -298,6 +318,7 @@
     "name": "Grace Carter",
     "gender": "female",
     "yearOfBirth": 2023,
+    "placeOfBirth": "Krakow, Poland",
     "parents": [
       "p10"
     ],
@@ -309,6 +330,7 @@
     "name": "Henry Carter",
     "gender": "male",
     "yearOfBirth": 2025,
+    "placeOfBirth": "Valencia, Spain",
     "parents": [
       "p11"
     ],
@@ -320,6 +342,7 @@
     "name": "Sophia Evans",
     "gender": "female",
     "yearOfBirth": 2022,
+    "placeOfBirth": "Antwerp, Belgium",
     "parents": [
       "p15"
     ],
@@ -331,6 +354,7 @@
     "name": "Jack Evans",
     "gender": "male",
     "yearOfBirth": 2024,
+    "placeOfBirth": "Turin, Italy",
     "parents": [
       "p14"
     ],
@@ -342,6 +366,7 @@
     "name": "Isabella Evans",
     "gender": "female",
     "yearOfBirth": 2025,
+    "placeOfBirth": "Genoa, Italy",
     "parents": [
       "p14"
     ],
@@ -353,6 +378,7 @@
     "name": "Mason Carter",
     "gender": "male",
     "yearOfBirth": 2025,
+    "placeOfBirth": "Antwerp, Belgium",
     "parents": [
       "p9"
     ],
@@ -364,6 +390,7 @@
     "name": "Ava Carter",
     "gender": "female",
     "yearOfBirth": 2025,
+    "placeOfBirth": "Gdansk, Poland",
     "parents": [
       "p10"
     ],
@@ -375,6 +402,7 @@
     "name": "Noah Smith",
     "gender": "male",
     "yearOfBirth": 2024,
+    "placeOfBirth": "Bruges, Belgium",
     "parents": [
       "p9"
     ],
@@ -386,6 +414,7 @@
     "name": "Mia Smith",
     "gender": "female",
     "yearOfBirth": 2025,
+    "placeOfBirth": "Warsaw, Poland",
     "parents": [
       "p10"
     ],
@@ -397,6 +426,7 @@
     "name": "Alex Johnson",
     "gender": "male",
     "yearOfBirth": 1980,
+    "placeOfBirth": "Utrecht, Netherlands",
     "parents": [],
     "spouses": [
       "p31"
@@ -411,6 +441,7 @@
     "name": "Emily Johnson",
     "gender": "female",
     "yearOfBirth": 1982,
+    "placeOfBirth": "Zagreb, Croatia",
     "parents": [],
     "spouses": [
       "p30"
@@ -425,6 +456,7 @@
     "name": "Ella Johnson",
     "gender": "female",
     "yearOfBirth": 2010,
+    "placeOfBirth": "Varanasi, India",
     "parents": [
       "p30",
       "p31"
@@ -437,6 +469,7 @@
     "name": "Liam Johnson",
     "gender": "male",
     "yearOfBirth": 2012,
+    "placeOfBirth": "Delhi, India",
     "parents": [
       "p30",
       "p31"
@@ -449,15 +482,22 @@
     "name": "Olivia Martinez",
     "gender": "female",
     "yearOfBirth": 1990,
+    "placeOfBirth": "Cusco, Peru",
     "parents": [],
-    "spouses": [],
-    "children": []
+    "spouses": [
+      "p44"
+    ],
+    "children": [
+      "p47",
+      "p48"
+    ]
   },
   {
     "id": "p35",
     "name": "Benjamin Lee",
     "gender": "male",
     "yearOfBirth": 1978,
+    "placeOfBirth": "Lviv, Ukraine",
     "parents": [],
     "spouses": [
       "p36"
@@ -471,6 +511,7 @@
     "name": "Chloe Lee",
     "gender": "female",
     "yearOfBirth": 1980,
+    "placeOfBirth": "Graz, Austria",
     "parents": [],
     "spouses": [
       "p35"
@@ -484,6 +525,7 @@
     "name": "Lucas Lee",
     "gender": "male",
     "yearOfBirth": 2015,
+    "placeOfBirth": "Manaus, Brazil",
     "parents": [
       "p35",
       "p36"
@@ -496,6 +538,7 @@
     "name": "Harper Kim",
     "gender": "female",
     "yearOfBirth": 2000,
+    "placeOfBirth": "Chiang Mai, Thailand",
     "parents": [],
     "spouses": [],
     "children": []
@@ -505,16 +548,892 @@
     "name": "Ethan Patel",
     "gender": "male",
     "yearOfBirth": 1995,
+    "placeOfBirth": "Da Nang, Vietnam",
     "parents": [],
-    "spouses": [],
-    "children": []
+    "spouses": [
+      "p43"
+    ],
+    "children": [
+      "p45",
+      "p46"
+    ]
   },
   {
     "id": "p40",
     "name": "Charlotte Nguyen",
     "gender": "female",
     "yearOfBirth": 1985,
+    "placeOfBirth": "Cork, Ireland",
     "parents": [],
+    "spouses": [
+      "p72"
+    ],
+    "children": [
+      "p75",
+      "p76"
+    ]
+  },
+  {
+    "id": "p41",
+    "name": "Carlos Garcia",
+    "gender": "male",
+    "yearOfBirth": 1953,
+    "placeOfBirth": "Granada, Spain",
+    "parents": [],
+    "spouses": [
+      "p42"
+    ],
+    "children": [
+      "p43",
+      "p44"
+    ]
+  },
+  {
+    "id": "p42",
+    "name": "Sofia Garcia",
+    "gender": "female",
+    "yearOfBirth": 1955,
+    "placeOfBirth": "Granada, Spain",
+    "parents": [],
+    "spouses": [
+      "p41"
+    ],
+    "children": [
+      "p43",
+      "p44"
+    ]
+  },
+  {
+    "id": "p43",
+    "name": "Maria Garcia",
+    "gender": "female",
+    "yearOfBirth": 1980,
+    "placeOfBirth": "Valencia, Spain",
+    "parents": [
+      "p41",
+      "p42"
+    ],
+    "spouses": [
+      "p39"
+    ],
+    "children": [
+      "p45",
+      "p46"
+    ]
+  },
+  {
+    "id": "p44",
+    "name": "Jose Garcia",
+    "gender": "male",
+    "yearOfBirth": 1982,
+    "placeOfBirth": "Seville, Spain",
+    "parents": [
+      "p41",
+      "p42"
+    ],
+    "spouses": [
+      "p34"
+    ],
+    "children": [
+      "p47",
+      "p48"
+    ]
+  },
+  {
+    "id": "p45",
+    "name": "Diego Patel",
+    "gender": "male",
+    "yearOfBirth": 2018,
+    "placeOfBirth": "Madrid, Spain",
+    "parents": [
+      "p43",
+      "p39"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p46",
+    "name": "Leila Patel",
+    "gender": "female",
+    "yearOfBirth": 2021,
+    "placeOfBirth": "Madrid, Spain",
+    "parents": [
+      "p43",
+      "p39"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p47",
+    "name": "Gabriel Garcia",
+    "gender": "male",
+    "yearOfBirth": 2015,
+    "placeOfBirth": "Bilbao, Spain",
+    "parents": [
+      "p44",
+      "p34"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p48",
+    "name": "Camila Garcia",
+    "gender": "female",
+    "yearOfBirth": 2017,
+    "placeOfBirth": "Bilbao, Spain",
+    "parents": [
+      "p44",
+      "p34"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p49",
+    "name": "Richard Anderson",
+    "gender": "male",
+    "yearOfBirth": 1948,
+    "placeOfBirth": "Denver, USA",
+    "parents": [],
+    "spouses": [
+      "p50"
+    ],
+    "children": [
+      "p51",
+      "p52"
+    ]
+  },
+  {
+    "id": "p50",
+    "name": "Linda Anderson",
+    "gender": "female",
+    "yearOfBirth": 1950,
+    "placeOfBirth": "Denver, USA",
+    "parents": [],
+    "spouses": [
+      "p49"
+    ],
+    "children": [
+      "p51",
+      "p52"
+    ]
+  },
+  {
+    "id": "p51",
+    "name": "Karen Anderson",
+    "gender": "female",
+    "yearOfBirth": 1975,
+    "placeOfBirth": "Phoenix, USA",
+    "parents": [
+      "p49",
+      "p50"
+    ],
+    "spouses": [
+      "p52"
+    ],
+    "children": [
+      "p53",
+      "p54",
+      "p55"
+    ]
+  },
+  {
+    "id": "p52",
+    "name": "Michael Anderson",
+    "gender": "male",
+    "yearOfBirth": 1973,
+    "placeOfBirth": "Phoenix, USA",
+    "parents": [],
+    "spouses": [
+      "p51"
+    ],
+    "children": [
+      "p53",
+      "p54",
+      "p55"
+    ]
+  },
+  {
+    "id": "p53",
+    "name": "Ethan Anderson",
+    "gender": "male",
+    "yearOfBirth": 2001,
+    "placeOfBirth": "Seattle, USA",
+    "parents": [
+      "p51",
+      "p52"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p54",
+    "name": "Grace Anderson",
+    "gender": "female",
+    "yearOfBirth": 2004,
+    "placeOfBirth": "Seattle, USA",
+    "parents": [
+      "p51",
+      "p52"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p55",
+    "name": "Lily Anderson",
+    "gender": "female",
+    "yearOfBirth": 2007,
+    "placeOfBirth": "Seattle, USA",
+    "parents": [
+      "p51",
+      "p52"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p56",
+    "name": "Amir Khan",
+    "gender": "male",
+    "yearOfBirth": 1952,
+    "placeOfBirth": "Lahore, Pakistan",
+    "parents": [],
+    "spouses": [
+      "p57"
+    ],
+    "children": [
+      "p58"
+    ]
+  },
+  {
+    "id": "p57",
+    "name": "Fatima Khan",
+    "gender": "female",
+    "yearOfBirth": 1954,
+    "placeOfBirth": "Lahore, Pakistan",
+    "parents": [],
+    "spouses": [
+      "p56"
+    ],
+    "children": [
+      "p58"
+    ]
+  },
+  {
+    "id": "p58",
+    "name": "Salman Khan",
+    "gender": "male",
+    "yearOfBirth": 1979,
+    "placeOfBirth": "Karachi, Pakistan",
+    "parents": [
+      "p56",
+      "p57"
+    ],
+    "spouses": [
+      "p59"
+    ],
+    "children": [
+      "p60",
+      "p61",
+      "p62"
+    ]
+  },
+  {
+    "id": "p59",
+    "name": "Aisha Khan",
+    "gender": "female",
+    "yearOfBirth": 1979,
+    "placeOfBirth": "Karachi, Pakistan",
+    "parents": [],
+    "spouses": [
+      "p58"
+    ],
+    "children": [
+      "p60",
+      "p61",
+      "p62"
+    ]
+  },
+  {
+    "id": "p60",
+    "name": "Imran Khan",
+    "gender": "male",
+    "yearOfBirth": 2004,
+    "placeOfBirth": "Islamabad, Pakistan",
+    "parents": [
+      "p58",
+      "p59"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p61",
+    "name": "Sara Khan",
+    "gender": "female",
+    "yearOfBirth": 2006,
+    "placeOfBirth": "Islamabad, Pakistan",
+    "parents": [
+      "p58",
+      "p59"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p62",
+    "name": "Zara Khan",
+    "gender": "female",
+    "yearOfBirth": 2009,
+    "placeOfBirth": "Islamabad, Pakistan",
+    "parents": [
+      "p58",
+      "p59"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p63",
+    "name": "Ivan Petrov",
+    "gender": "male",
+    "yearOfBirth": 1946,
+    "placeOfBirth": "Moscow, Russia",
+    "parents": [],
+    "spouses": [
+      "p64"
+    ],
+    "children": [
+      "p65"
+    ]
+  },
+  {
+    "id": "p64",
+    "name": "Olga Petrov",
+    "gender": "female",
+    "yearOfBirth": 1947,
+    "placeOfBirth": "Moscow, Russia",
+    "parents": [],
+    "spouses": [
+      "p63"
+    ],
+    "children": [
+      "p65"
+    ]
+  },
+  {
+    "id": "p65",
+    "name": "Nikolai Petrov",
+    "gender": "male",
+    "yearOfBirth": 1974,
+    "placeOfBirth": "Saint Petersburg, Russia",
+    "parents": [
+      "p63",
+      "p64"
+    ],
+    "spouses": [
+      "p66"
+    ],
+    "children": [
+      "p67",
+      "p68",
+      "p69"
+    ]
+  },
+  {
+    "id": "p66",
+    "name": "Elena Petrov",
+    "gender": "female",
+    "yearOfBirth": 1975,
+    "placeOfBirth": "Saint Petersburg, Russia",
+    "parents": [],
+    "spouses": [
+      "p65"
+    ],
+    "children": [
+      "p67",
+      "p68",
+      "p69"
+    ]
+  },
+  {
+    "id": "p67",
+    "name": "Dmitri Petrov",
+    "gender": "male",
+    "yearOfBirth": 2001,
+    "placeOfBirth": "Novosibirsk, Russia",
+    "parents": [
+      "p65",
+      "p66"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p68",
+    "name": "Katya Petrov",
+    "gender": "female",
+    "yearOfBirth": 2004,
+    "placeOfBirth": "Novosibirsk, Russia",
+    "parents": [
+      "p65",
+      "p66"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p69",
+    "name": "Mikhail Petrov",
+    "gender": "male",
+    "yearOfBirth": 2007,
+    "placeOfBirth": "Novosibirsk, Russia",
+    "parents": [
+      "p65",
+      "p66"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p70",
+    "name": "Patrick O'Neil",
+    "gender": "male",
+    "yearOfBirth": 1948,
+    "placeOfBirth": "Limerick, Ireland",
+    "parents": [],
+    "spouses": [
+      "p71"
+    ],
+    "children": [
+      "p72",
+      "p73"
+    ]
+  },
+  {
+    "id": "p71",
+    "name": "Bridget O'Neil",
+    "gender": "female",
+    "yearOfBirth": 1950,
+    "placeOfBirth": "Limerick, Ireland",
+    "parents": [],
+    "spouses": [
+      "p70"
+    ],
+    "children": [
+      "p72",
+      "p73"
+    ]
+  },
+  {
+    "id": "p72",
+    "name": "Sean O'Neil",
+    "gender": "male",
+    "yearOfBirth": 1975,
+    "placeOfBirth": "Dublin, Ireland",
+    "parents": [
+      "p70",
+      "p71"
+    ],
+    "spouses": [
+      "p40"
+    ],
+    "children": [
+      "p75",
+      "p76"
+    ]
+  },
+  {
+    "id": "p73",
+    "name": "Maureen O'Neil",
+    "gender": "female",
+    "yearOfBirth": 1978,
+    "placeOfBirth": "Dublin, Ireland",
+    "parents": [
+      "p70",
+      "p71"
+    ],
+    "spouses": [
+      "p74"
+    ],
+    "children": [
+      "p77"
+    ]
+  },
+  {
+    "id": "p74",
+    "name": "Conor O'Neil",
+    "gender": "male",
+    "yearOfBirth": 1976,
+    "placeOfBirth": "Dublin, Ireland",
+    "parents": [],
+    "spouses": [
+      "p73"
+    ],
+    "children": [
+      "p77"
+    ]
+  },
+  {
+    "id": "p75",
+    "name": "Liam O'Neil",
+    "gender": "male",
+    "yearOfBirth": 2008,
+    "placeOfBirth": "Galway, Ireland",
+    "parents": [
+      "p72",
+      "p40"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p76",
+    "name": "Niamh O'Neil",
+    "gender": "female",
+    "yearOfBirth": 2010,
+    "placeOfBirth": "Galway, Ireland",
+    "parents": [
+      "p72",
+      "p40"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p77",
+    "name": "Aiden O'Neil",
+    "gender": "male",
+    "yearOfBirth": 2012,
+    "placeOfBirth": "Cork, Ireland",
+    "parents": [
+      "p73",
+      "p74"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p78",
+    "name": "Hiroshi Tanaka",
+    "gender": "male",
+    "yearOfBirth": 1951,
+    "placeOfBirth": "Sapporo, Japan",
+    "parents": [],
+    "spouses": [
+      "p79"
+    ],
+    "children": [
+      "p80"
+    ]
+  },
+  {
+    "id": "p79",
+    "name": "Keiko Tanaka",
+    "gender": "female",
+    "yearOfBirth": 1953,
+    "placeOfBirth": "Sapporo, Japan",
+    "parents": [],
+    "spouses": [
+      "p78"
+    ],
+    "children": [
+      "p80"
+    ]
+  },
+  {
+    "id": "p80",
+    "name": "Kenji Tanaka",
+    "gender": "male",
+    "yearOfBirth": 1978,
+    "placeOfBirth": "Tokyo, Japan",
+    "parents": [
+      "p78",
+      "p79"
+    ],
+    "spouses": [
+      "p81"
+    ],
+    "children": [
+      "p82",
+      "p83",
+      "p84"
+    ]
+  },
+  {
+    "id": "p81",
+    "name": "Yuki Tanaka",
+    "gender": "female",
+    "yearOfBirth": 1980,
+    "placeOfBirth": "Tokyo, Japan",
+    "parents": [],
+    "spouses": [
+      "p80"
+    ],
+    "children": [
+      "p82",
+      "p83",
+      "p84"
+    ]
+  },
+  {
+    "id": "p82",
+    "name": "Takumi Tanaka",
+    "gender": "male",
+    "yearOfBirth": 2006,
+    "placeOfBirth": "Osaka, Japan",
+    "parents": [
+      "p80",
+      "p81"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p83",
+    "name": "Reina Tanaka",
+    "gender": "female",
+    "yearOfBirth": 2009,
+    "placeOfBirth": "Osaka, Japan",
+    "parents": [
+      "p80",
+      "p81"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p84",
+    "name": "Kaito Tanaka",
+    "gender": "male",
+    "yearOfBirth": 2011,
+    "placeOfBirth": "Osaka, Japan",
+    "parents": [
+      "p80",
+      "p81"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p85",
+    "name": "Jacques Dubois",
+    "gender": "male",
+    "yearOfBirth": 1949,
+    "placeOfBirth": "Lyon, France",
+    "parents": [],
+    "spouses": [
+      "p86"
+    ],
+    "children": [
+      "p87"
+    ]
+  },
+  {
+    "id": "p86",
+    "name": "Marie Dubois",
+    "gender": "female",
+    "yearOfBirth": 1951,
+    "placeOfBirth": "Lyon, France",
+    "parents": [],
+    "spouses": [
+      "p85"
+    ],
+    "children": [
+      "p87"
+    ]
+  },
+  {
+    "id": "p87",
+    "name": "Pierre Dubois",
+    "gender": "male",
+    "yearOfBirth": 1976,
+    "placeOfBirth": "Marseille, France",
+    "parents": [
+      "p85",
+      "p86"
+    ],
+    "spouses": [
+      "p88"
+    ],
+    "children": [
+      "p89",
+      "p90",
+      "p91"
+    ]
+  },
+  {
+    "id": "p88",
+    "name": "Claire Dubois",
+    "gender": "female",
+    "yearOfBirth": 1978,
+    "placeOfBirth": "Marseille, France",
+    "parents": [],
+    "spouses": [
+      "p87"
+    ],
+    "children": [
+      "p89",
+      "p90",
+      "p91"
+    ]
+  },
+  {
+    "id": "p89",
+    "name": "Julien Dubois",
+    "gender": "male",
+    "yearOfBirth": 2003,
+    "placeOfBirth": "Nice, France",
+    "parents": [
+      "p87",
+      "p88"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p90",
+    "name": "Louise Dubois",
+    "gender": "female",
+    "yearOfBirth": 2005,
+    "placeOfBirth": "Nice, France",
+    "parents": [
+      "p87",
+      "p88"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p91",
+    "name": "Hugo Dubois",
+    "gender": "male",
+    "yearOfBirth": 2007,
+    "placeOfBirth": "Nice, France",
+    "parents": [
+      "p87",
+      "p88"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p92",
+    "name": "Seamus Murphy",
+    "gender": "male",
+    "yearOfBirth": 1947,
+    "placeOfBirth": "Galway, Ireland",
+    "parents": [],
+    "spouses": [
+      "p93"
+    ],
+    "children": [
+      "p94",
+      "p96"
+    ]
+  },
+  {
+    "id": "p93",
+    "name": "Nora Murphy",
+    "gender": "female",
+    "yearOfBirth": 1948,
+    "placeOfBirth": "Galway, Ireland",
+    "parents": [],
+    "spouses": [
+      "p92"
+    ],
+    "children": [
+      "p94",
+      "p96"
+    ]
+  },
+  {
+    "id": "p94",
+    "name": "Declan Murphy",
+    "gender": "male",
+    "yearOfBirth": 1972,
+    "placeOfBirth": "Dublin, Ireland",
+    "parents": [
+      "p92",
+      "p93"
+    ],
+    "spouses": [
+      "p95"
+    ],
+    "children": [
+      "p98",
+      "p99"
+    ]
+  },
+  {
+    "id": "p95",
+    "name": "Roisin Murphy",
+    "gender": "female",
+    "yearOfBirth": 1974,
+    "placeOfBirth": "Dublin, Ireland",
+    "parents": [],
+    "spouses": [
+      "p94"
+    ],
+    "children": [
+      "p98",
+      "p99"
+    ]
+  },
+  {
+    "id": "p96",
+    "name": "Kathleen Murphy",
+    "gender": "female",
+    "yearOfBirth": 1975,
+    "placeOfBirth": "Cork, Ireland",
+    "parents": [
+      "p92",
+      "p93"
+    ],
+    "spouses": [
+      "p97"
+    ],
+    "children": []
+  },
+  {
+    "id": "p97",
+    "name": "Brian O'Sullivan",
+    "gender": "male",
+    "yearOfBirth": 1974,
+    "placeOfBirth": "Cork, Ireland",
+    "parents": [],
+    "spouses": [
+      "p96"
+    ],
+    "children": []
+  },
+  {
+    "id": "p98",
+    "name": "Aoife Murphy",
+    "gender": "female",
+    "yearOfBirth": 2000,
+    "placeOfBirth": "Limerick, Ireland",
+    "parents": [
+      "p94",
+      "p95"
+    ],
+    "spouses": [],
+    "children": []
+  },
+  {
+    "id": "p99",
+    "name": "Cillian Murphy",
+    "gender": "male",
+    "yearOfBirth": 2003,
+    "placeOfBirth": "Limerick, Ireland",
+    "parents": [
+      "p94",
+      "p95"
+    ],
     "spouses": [],
     "children": []
   }


### PR DESCRIPTION
## Summary
- expanded `people.json` with 59 new entries forming 8 families across three generations
- linked new members to existing singles (e.g. Ethan Patel, Olivia Martinez, and Charlotte Nguyen)

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a493eba608324942f59344b4be365